### PR TITLE
feat: possible upgrade of search method in ad service, fix for warnin…

### DIFF
--- a/data-access/Models/Ad.cs
+++ b/data-access/Models/Ad.cs
@@ -6,15 +6,6 @@ namespace DAL.Models
     [Table("Ads")]
     public class Ad : BaseModel
     {
-        //public Ad(string name, string description, float price, string imageURL)
-        //{
-        //    Name = name;
-        //    Description = description;
-        //    Rate = 0;
-        //    Price = price;
-        //    ImageURL = imageURL;
-        //}
-
         [Column("Name")]
         public string Name { get; set; }
 

--- a/data-access/Repositories/Repository.cs
+++ b/data-access/Repositories/Repository.cs
@@ -55,12 +55,12 @@ namespace DAL.Repositories
 
         public async Task<IQueryable<T>> GetByRangeAsync(int skip, int number)
         {
-            return await Task.Run(() => _entities.Skip(skip).Take(number));
+            return await Task.Run(() => _entities.OrderByDescending(x => x.CreatedDate).Skip(skip).Take(number));
         }
 
         public async Task<IQueryable<T>> GetByRangeAsync(int skip, int number, Expression<Func<T, bool>> expression)
         {
-            return await Task.Run(() => _entities.Where(expression).Skip(skip).Take(number).AsNoTracking());
+            return await Task.Run(() => _entities.Where(expression).OrderByDescending(x => x.CreatedDate).Skip(skip).Take(number).AsNoTracking());
         }
 
         public async Task<IQueryable<T>> GetByConditionAsync(Expression<Func<T, bool>> expression)

--- a/turradgiver-api/Utils/Response.cs
+++ b/turradgiver-api/Utils/Response.cs
@@ -1,9 +1,0 @@
-﻿// namespace turradgiver_api.Utils
-// {
-//     public class Response<T>
-//     {
-//         public T Data { get; set; }
-//         public bool Success { get; set; } = true;
-//         public string Message { get; set; } = null;
-//     }
-// }


### PR DESCRIPTION
Change for search service.
In `GetAdsAsync` and `GetUserAdsAsync` the behavior is the same except the expression taht vary depending on the `criterias.Search` dto props.

So instead of having both method with the same behavior I've refactored the methods as follow
- `Search` -> need an **expression**, the **page number** and the **number of items**
- `GetAdsAsync` -> received the searchCriteria and `call Search` with specific **expressions** and **page number**
- `GetUserAdsAsync` -> received the searchCriteria and `call Search` with specific **expressions (user check)** and **page number**

For the `GetAdsAsync` we can think about rewritting a little bit the Search functin in order to avoid the useless expression for this use case:
```cs
Expression<Func<Ad,bool>> exp = criterias.Search != null 
                ? (e => e.Name.Contains(criterias.Search) || e.Description.Contains(criterias.Search))
                : (e=> true);
```
When the user fetch de ad without criterias it should return all the existing ads for the page, so instead of calling `GetByRangeAsync` in `Search` without expression, I've decided to add a "dummy* expression,

We could change that by setting `exp` to `null` and by checking in `Search` method if exp == null and if it's the case call `GetByRangeAsync` without expression parameter

🤔 